### PR TITLE
Revert "chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.1 to 4.31.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5364,13 +5364,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.31.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz",
-      "integrity": "sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==",
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
+      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.31.2",
-        "@typescript-eslint/scope-manager": "4.31.2",
+        "@typescript-eslint/experimental-utils": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.29.1",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -5378,61 +5378,6 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "4.31.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz",
-          "integrity": "sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.7",
-            "@typescript-eslint/scope-manager": "4.31.2",
-            "@typescript-eslint/types": "4.31.2",
-            "@typescript-eslint/typescript-estree": "4.31.2",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "4.31.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz",
-          "integrity": "sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.31.2",
-            "@typescript-eslint/visitor-keys": "4.31.2"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.31.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.2.tgz",
-          "integrity": "sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.31.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz",
-          "integrity": "sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.31.2",
-            "@typescript-eslint/visitor-keys": "4.31.2",
-            "debug": "^4.3.1",
-            "globby": "^11.0.3",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.31.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz",
-          "integrity": "sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.31.2",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@semantic-release/npm": "^7.1.3",
     "@semantic-release/release-notes-generator": "^9.0.3",
     "@types/jest": "^26.0.24",
-    "@typescript-eslint/eslint-plugin": "^4.31.2",
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.3",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
Reverts bbeesley/gha-auto-dependabot-rebase#45

JSON parse errors when new arg is not supplied